### PR TITLE
Remove unused err.h header file

### DIFF
--- a/rabin.c
+++ b/rabin.c
@@ -1,4 +1,3 @@
-#include <err.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include "rabin.h"


### PR DESCRIPTION
err.h is BSD specific so prevents [rabin-native](https://github.com/hyperdivision/rabin-native) from building on windows.

err.h was included for `errx()` which was removed from `rabin.c` in 453395bc8e2af663a3479d3c84533fe256820f60 so nothing is changed by omitting it